### PR TITLE
Fixed readme and changed multi_deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ $ python3 multi_application_train.py 1 binary esample nonsym,sym
 ```console
 $ python3 multi_deploy.py [modelNumber] [expname] [datasetname] [class_list_comma_sep] 
 $ python3 multi_deploy.py 8 multi hvttraindata H,R,T,V
+
+```
+```console
+$ python multi_deploy.py --help
+usage: multi_deploy.py [-h] [-ver] [-nocol] [-q | -v]
+                       MODEL_NUMBER EXP_NAME DATASET_NAME CLASSES
+
+mlsymmetric
+
+positional arguments:
+  MODEL_NUMBER       Model number
+  EXP_NAME           Name of experiment directory
+  DATASET_NAME       Dataset directory
+  CLASSES            List of classes
+
+optional arguments:
+  -h, --help         show this help message and exit
+  -ver, --version    Display version information and dependencies.
+  -nocol, --nocolor  Disables color in terminal
+  -q, --quiet        Print quiet
+  -v, --verbose      Print verbose
 ```
 
 ## Team

--- a/multi_deploy.py
+++ b/multi_deploy.py
@@ -13,195 +13,137 @@ from keras.callbacks import CSVLogger
 import json
 from sklearn.metrics import confusion_matrix
 
-#run python3 deploy.py num_class modelnumber checkpoint_dir test_img_dir out_csv
-#python3 deploy.py 2 8 outputs/binary/models/ testdataset/imagesWelsh/ out.csv
-#python3 deploy.py 4 8 outputs/multi/models/ testdataset/wild/frominternet/ testdataset/wild/frominternet_multi.csv
-#binary
-#python3 deploy.py 2 8 outputs/binary/models/ dataset/esample/randomtest/  prediction.csv
+import argparse
+# from colorama import Fore, Style, init
 
-#python3 multi_deploy.py [modelNumber] [expname] [datasetname] [class_list_comma_sep]  
+module_name = "mlsymmetric"
 
-#python3 multi_deploy.py 8 multi hvttraindata H,R,T,V
+parser = argparse.ArgumentParser(description = "mlsymmetric")
+parser.add_argument('model_num', 
+                        metavar = 'MODEL_NUMBER', type=int,
+                        help='Model number')
+parser.add_argument('exp_name', 
+                        metavar = 'EXP_NAME', type=str,
+                        help='Name of experiment directory')
+parser.add_argument('dataset_name', 
+                        metavar = 'DATASET_NAME', type=str,
+                        help='Dataset directory')
+parser.add_argument('classes', 
+                        metavar = 'CLASSES', type=str,
+                        help='List of classes')
+parser.add_argument('-ver', '--version',
+                        action='version',  version="1.0",
+                        help='Display version information and dependencies.')
+parser.add_argument('-nocol', '--nocolor',
+                        action='store_true', default = False, 
+                        help='Disables color in terminal')
+detail = parser.add_mutually_exclusive_group()
+detail.add_argument('-q', '--quiet',
+                        action='store_true', 
+                        help='Print quiet')
+detail.add_argument('-v', '--verbose',
+                        action='store_true', 
+                        help='Print verbose')
+args = parser.parse_args()
+
 rootoutput='outputs/'
 rootdataset='dataset/'
- 
 
-ModelNumber=int(sys.argv[1])-1
-#classes=int(sys.argv[2])
-expprefix=sys.argv[2]
-datasetname=sys.argv[3]
-classes_name=sys.argv[4].split(",")
-classes=len(classes_name)
+model_num = args.model_num - 1
+exp_name = args.exp_name
+dataset_name = args.dataset_name
+class_list = args.classes.split(',')
+n_classes = len(class_list)
 
-test_path=rootdataset + datasetname + "/test/"
-checkpoint_dir= rootoutput + expprefix+"/models/" # "outputs/multirefrottarAll/models/"
+test_path = rootdataset + dataset_name + "/test/"
+checkpoint_dir = rootoutput + exp_name + "/models/"
 
-print("test_path", test_path)
-print("checkpoint_dir", checkpoint_dir)
-print("classes",classes_name)
-
-
-start=timer()
-
-#classes=int(sys.argv[1])#2
-
-#i=8#int(sys.argv[1])-1
-
-#wild_path = 'esample/manualtest'
-#wild_path =sys.argv[1]
-
-#validation_data_dir =  'esample/valid'
- 
-#checkpoint_dir="outputs/binary/models/"
-
-#validation_data_dir='binary_data/test/'
-#10_InceptionResNetV2_checkpoint.best.hdf5
 '''
-classes=int(sys.argv[1]) #2
-i=int(sys.argv[2]) #8
-checkpoint_dir=sys.argv[3]
-wild_path= sys.argv[4]
-outfile=sys.argv[5]
-
-''' 
-'''
-classes=3
-i=8
-
-wild_path= "dataset/hvttraindata/test/"
-outfile="prediction.csv"
-classes_name=["nonsym","sym"]
-#validation_data_dir="dataset/hvttraindata/valid/"
-#test_path= "dataset/hvttraindata/test/"
-#test_path= "testdataset/wildnatural/test/"
-test_path= "dataset/multi_ref_rot_tra/test/"
- 
-checkpoint_dir="outputs/multirefrottarAll/models/"
-
-
-classes=int(sys.argv[1]) #2
-modelNumber=int(sys.argv[2]) -1 #8
-checkpoint_dir=sys.argv[3]
-test_path= sys.argv[4]
-outfile=sys.argv[5]
-
-
-#target_names =  ["ref","rot","tar"]
-#target_names =  ["H","R","T","V"]
+if not args.nocolor:
+    init()
 '''
 
-calculatepercentage=0
-input_shape=(200,200,1)
+if not args.quiet:        
+    print("Test Path:", test_path)
+    print("Checkpoint Directory:", checkpoint_dir)
+    print("Classes:", class_list)
+
+
+start = timer()
+
+# When is this used?
+calculatepercentage = 0
+
+input_shape = (200,200,1) 
 img_width, img_height = 200, 200
 
-#batch_size=1
 V_batch_size=32
 
- 
-#classes_name#=target_names
+names = [
+        'ResNet50',
+        'MobileNet',
+        'MobileNetV2',
+        'NASNetMobile',
+        'NASNetLarge',
+        'VGG16',
+        'VGG19',
+        'Xception',
+        'InceptionResNetV2',
+        'DenseNet121',
+        'DenseNet201'
+        ]
 
+models = [
+    keras_applications.ResNet50, 
+    keras_applications.MobileNet,  
+    keras_applications.MobileNetV2, 
+    keras_applications.NASNetMobile, 
+    keras_applications.NASNetLarge, 
+    keras_applications.VGG16, 
+    keras_applications.VGG19, 
+    keras_applications.Xception, 
+    keras_applications.InceptionResNetV2,
+    keras_applications.DenseNet121,
+    keras_applications.DenseNet201
+    ]
 
-names=['ResNet50',   'MobileNet', 'MobileNetV2', 'NASNetMobile', 'NASNetLarge', 'VGG16', 'VGG19', 'Xception', 'InceptionResNetV2', 'DenseNet121', 'DenseNet201']
+model_name = str(model_num)+ "_" + names[model_num]
 
+if not args.quiet:
+    print("Model:", model_name)
 
-m=[keras_applications.ResNet50, keras_applications.MobileNet,  keras_applications.MobileNetV2, keras_applications.NASNetMobile, keras_applications.NASNetLarge, keras_applications.VGG16, keras_applications.VGG19, keras_applications.Xception, keras_applications.InceptionResNetV2,
-keras_applications.DenseNet121,keras_applications.DenseNet201]
+model = models[model_num](weights = None, input_shape = input_shape, classes = n_classes)
+model.compile(optimizer = 'adam', loss = 'categorical_crossentropy', metrics = ['accuracy'])
 
+weightfile = checkpoint_dir + model_name + '_checkpoint.best.hdf5'
+if not args.quiet:
+    print("loading model", weightfile)
+    
+model.load_weights(weightfile)
 
-modelname= str(ModelNumber)+"_"+ names[ModelNumber]
-print(modelname)
-
-model=m[ModelNumber](weights=None, input_shape=input_shape,classes=classes)
-model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
-weigthfile=checkpoint_dir+modelname+'_checkpoint.best.hdf5'
-print("loading model",weigthfile)
-model.load_weights(weigthfile)
+# When is wild_datagen used?
 wild_datagen = ImageDataGenerator(rescale = 1. / 255)
 
-'''
-validation_generator = wild_datagen.flow_from_directory(    validation_data_dir,   classes= classes_name, target_size =(img_width, img_height),          batch_size = V_batch_size,  class_mode='categorical',color_mode="grayscale")
-
-validation_generator = wild_datagen.flow_from_directory(
-                                    validation_data_dir,
-                   target_size =(img_width, img_height),
-          batch_size = V_batch_size,  class_mode='categorical',color_mode="grayscale")
-
-'''
 test_datagen = ImageDataGenerator(rescale = 1. / 255)
-test_generator = test_datagen.flow_from_directory(    test_path,   classes= classes_name, target_size =(img_width, img_height),          batch_size = V_batch_size, shuffle=False, class_mode='categorical',color_mode="grayscale")
+test_generator = test_datagen.flow_from_directory(test_path, classes = class_list, 
+                target_size = (img_width, img_height), batch_size = V_batch_size, shuffle = False,
+                class_mode = 'categorical', color_mode = "grayscale")
 
-'''
-wild_generator = wild_datagen.flow_from_directory(wild_path  ,
-                              target_size =(img_width, img_height),
-                     batch_size = V_batch_size, classes=None, shuffle=False, class_mode='categorical',color_mode="grayscale")
-'''
-
-#model.fit_generator(train_generator, steps_per_epoch = nb_train_samples // batch_size, epochs = epochs, validation_data = validation_generator, validation_steps = nb_validation_samples // batch_size )
-#import pdb; pdb.set_trace()
-steps =  np.ceil(test_generator.samples/V_batch_size)
-Y_pred = model.predict_generator(test_generator, steps=steps)
+steps =  np.ceil(test_generator.samples / V_batch_size)
+Y_pred = model.predict_generator(test_generator, steps = steps)
 
 acclasses = test_generator.classes[test_generator.index_array]
-y_pred = np.argmax(Y_pred, axis=-1)
-print(modelname, "acc percentage", sum(y_pred==acclasses)/len(Y_pred))
+y_pred = np.argmax(Y_pred, axis = -1)
+print(model_name, "acc percentage", sum(y_pred == acclasses)/len(Y_pred))
+if not args.quiet:
+    print(confusion_matrix(acclasses, y_pred))
 
-print(confusion_matrix(acclasses,y_pred))
+file_names = np.array(test_generator.filenames)
 
+name_nums = np.zeros(file_names.size, dtype = [('names', 'U30'), ('y_pred', int), ('acclasses', int)])
+name_nums['names'] = file_names
+name_nums['y_pred'] = y_pred
+name_nums['acclasses'] = acclasses
 
-
-
-np.savetxt('pred.csv',y_pred,delimiter=',')
-np.savetxt('acclasses.csv',acclasses,delimiter=',')
-#np.savetxt('fname.csv',test_generator.filenames,delimiter=',')
-
-#t=np.column_stack(test_generator.filenames,acclasses,y_pred)
-#np.savetxt('t.csv',t,delimiter=',')
-
-'''
-y_pred = np.argmax(Y_pred, axis=1)
-wildclass=[target_names[i] for  i in  y_pred]
-
-#steps =  np.ceil(wild_generator.samples/V_batch_size)
-#steps= wild_gener.samples
-#loss, acc = model.evaluate_generator(wild_generator, steps=steps, verbose=0)
-
-#print(loss, acc)
-
-
-#print('Confusion Matrix')
-
-
-#print(wildclass)
-#print(wild_generator.filenames)
-print(modelname)
-
-
-data=open(wild_path+ modelname +"_"+outfile,"w")
-data.write("filename_"+modelname+",predictedclass, " + target_names[0] + "-score," + target_names[1]+"-score\n")
-for i in range(0, len(y_pred)):
-	a=wild_generator.filenames[i] + ","+ wildclass[i]+ ","+ str( Y_pred[i][0]) + ","+ str( Y_pred[i][1]) + "\n"
-	#print(a)
-	data.write(a)
-
-data.close()
-
-
-def findpercentage(wildclass,o):
-    sum=0
-    for i in range(0, len(o)):
-        if wildclass[i]==o[i]:
-            sum=sum+1
-            #print ("match",wildclass[i],o[i] )
-    return sum/len(o)
-
-if calculatepercentage==1:
-	o=[a.split("-")[1] for a in wild_generator.filenames]
-	#import pdb; pdb.set_trace()
-	print(" percentage", findpercentage(wildclass,o) )
-
-#oa=zip(wildclass,0)
-#print(tuple(oa))
-#import pdb; pdb.set_trace()
-
-
-'''
+np.savetxt('name_pred_acc.csv', name_nums, delimiter = ',', header = "File Name\t\tP. Class\tA. Class", fmt = "%s\t%i\t\t%i")
+print("name_pred_acc.csv has been created.")

--- a/multi_deploy.py
+++ b/multi_deploy.py
@@ -143,7 +143,8 @@ file_names = np.array(test_generator.filenames)
 name_nums = np.zeros(file_names.size, dtype = [('names', 'U30'), ('y_pred', int), ('acclasses', int)])
 name_nums['names'] = file_names
 name_nums['y_pred'] = y_pred
+# Add Y_Pred
 name_nums['acclasses'] = acclasses
 
-np.savetxt('name_pred_acc.csv', name_nums, delimiter = ',', header = "File Name\t\tP. Class\tA. Class", fmt = "%s\t%i\t\t%i")
+np.savetxt('name_pred_acc.csv', name_nums, delimiter = ',', header = "File Name,P. Class,A. Class", fmt = "%s%i%i")
 print("name_pred_acc.csv has been created.")


### PR DESCRIPTION
Changed multi_deploy to use argparser module. Changed some variable names and deleted commented code. Ran prediction again to make sure it worked. multi_deploy now creates name_pred_acc.csv which prints out the file name, y_pred, and acclasses for each file in test set.

Ran --help and pasted usage message into README.md, so that's also been changed a bit. In the future I can apply the changes to multi_application_train.py and all other py files in repo. 